### PR TITLE
Search Box padding for Search Page

### DIFF
--- a/Naut CSS.css
+++ b/Naut CSS.css
@@ -1881,7 +1881,7 @@
 				}
 
 				.search-page #search input[type=text] {
-					padding: 5px 0px 5px 40px;
+					padding: 5px 0px 5px 17px;
 					font-size: 150%;
 				}
 


### PR DESCRIPTION
Reduced left padding for search box on search page to fit in line with sidebar padding.

40px to 17px (Same as sidebar, 40px is too wide)