### PR TITLE
Fix expanded search button in sidebar

### DIFF
--- a/Naut CSS.css
+++ b/Naut CSS.css
@@ -654,12 +654,12 @@
 									.search-page form#search label {font-size: 150%;cursor: pointer;}
 
 					#search input[type=submit] {
+						color: transparent;
 						margin-left: 0px;
 						height: 30px;
 						margin-top: 16px;
 						width: 42px;
 						border: 1px solid #D5D5D5;
-						border-right: 0px solid;
 						background: rgba(0,0,0,0);
 						background-image: url(%%spritesheet%%) !important;
 						background-position: -130px -1px !important;


### PR DESCRIPTION
At the moment when expanding the seachbox in the sidebar, the secondary search button (underneath "limit my search" has no right border, and has the search icon and "Search" text overlapping. 

Added "color: transparent;" to hide the "Search" text
Removed "border-right: 0px solid;" to implement a right border on the search button (via "border: 1px solid #D5D5D5;")