### PR TITLE
Fix search expando label padding

### DIFF
--- a/NAUT 3 - Main CSS File.css
+++ b/NAUT 3 - Main CSS File.css
@@ -2648,8 +2648,6 @@
 						height: auto;
 					}
 
-						.res #search #searchexpando label {padding: 13px 0px;}
-
 						.res #searchexpando .searchexpando-submit {display: none;}
 
 					.res h1.hover.redditname {margin-bottom: 28px;}


### PR DESCRIPTION
Fixes an issue with the label padding in the search expando.

Before fix:
![before](https://cloud.githubusercontent.com/assets/371507/6499918/108f8bf0-c2d1-11e4-8322-65129937279b.png)

After fix:
![after](https://cloud.githubusercontent.com/assets/371507/6499921/13f524c6-c2d1-11e4-8ebc-c2f8ecaf97d0.png)