### PR TITLE
Small fix.

### DIFF
--- a/Addons/User Flair Images/User Flair Images.css
+++ b/Addons/User Flair Images/User Flair Images.css
@@ -18,5 +18,5 @@
 .flair-one:before{background-position:0 -0}
 .flair-two:before{background-position:0 -16px}
 .flair-three:before{background-position:0 -32px}
-.flair-four:before{background-position:0 -48px}}
+.flair-four:before{background-position:0 -48px}
 /* End Addon */


### PR DESCRIPTION
With the extra bracket, you'd get a syntax error: EOF reached before {} block for a qualified rule when trying to add / apply this plugin.