### PR TITLE
Grey out and disable archived post voting arrows (#125)

### DIFF
--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -2544,6 +2544,22 @@ div.titlebox span.number:after {
     font-weight: 700;
 }
 
+/* Archived Posts */
+    /* Disable Arrows */
+    .archived-infobar + style + #siteTable .thing .arrow,
+    .archived-infobar + style + #siteTable + .commentarea .thing .arrow {
+        pointer-events: none;
+    }
+    /* Gray Arrows */
+    .archived-infobar + style + #siteTable .thing .arrow.up,
+    .archived-infobar + style + #siteTable + .commentarea .thing .arrow.up {
+        opacity: .12;
+    }
+    .archived-infobar + style + #siteTable .thing .arrow.down,
+    .archived-infobar + style + #siteTable + .commentarea .thing .arrow.down {
+        opacity: .17;
+    }
+
 /* RES Fixes / RES Nightmode */
 /* Voting Arrows */
 .res-nightmode .arrow {

--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -487,7 +487,7 @@ body > .content .link .rank, .rank-spacer {
 .arrow {
     margin: 0;
     background-image: url(%%spritesheet%%) !important;
-    width: 33px;
+    width: 32px;
     border-radius: 2px;
     transition: background-color .25s ease;
 }

--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -2544,6 +2544,18 @@ div.titlebox span.number:after {
     font-weight: 700;
 }
 
+    /* Archived Posts */
+    /* Disable Voting Arrows */
+    .thing .arrow.archived {
+        pointer-events: none;
+    }
+    .thing .arrow.archived.up {
+        opacity: .1;
+    }
+    .thing .arrow.archived.down {
+        opacity: .2;
+    }
+
 /* RES Fixes / RES Nightmode */
 /* Voting Arrows */
 .res-nightmode .arrow {

--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -3762,6 +3762,7 @@ ul.image-preview-list {
 
     .res #header-bottom-right .user a {
         font-size: 11px;
+        line-height: 9px;
     }
 
 .res #sr-header-area a.RESShortcutsCurrentSub, .res #RESSubredditGroupDropdown .RESShortcutsCurrentSub a {

--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -320,9 +320,8 @@ body:not(.loggedin) #header-bottom-right {
     /* Fix comments page sorting options
        being on top of the havemail element */
     .commentarea .panestack-title,
-    .commentarea .menuarea,
-    .commentarea .sitetable {
-        z-index: -1;
+    .commentarea .menuarea {
+        z-index: 0;
     }
 
 #modmail {

--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -2544,22 +2544,6 @@ div.titlebox span.number:after {
     font-weight: 700;
 }
 
-/* Archived Posts */
-    /* Disable Arrows */
-    .archived-infobar + style + #siteTable .thing .arrow,
-    .archived-infobar + style + #siteTable + .commentarea .thing .arrow {
-        pointer-events: none;
-    }
-    /* Gray Arrows */
-    .archived-infobar + style + #siteTable .thing .arrow.up,
-    .archived-infobar + style + #siteTable + .commentarea .thing .arrow.up {
-        opacity: .12;
-    }
-    .archived-infobar + style + #siteTable .thing .arrow.down,
-    .archived-infobar + style + #siteTable + .commentarea .thing .arrow.down {
-        opacity: .17;
-    }
-
 /* RES Fixes / RES Nightmode */
 /* Voting Arrows */
 .res-nightmode .arrow {


### PR DESCRIPTION
Will gray out and remove voting rights on archived posts, and all subsequent comment voting arrows.

Note: There are a few other residual fixes in place here as well (from the last pull/commit).