### PR TITLE
Fix flair class on post overwriting the link flair selector classes

### DIFF
--- a/Addons/Link Flair Customization/Link Flair Customization.css
+++ b/Addons/Link Flair Customization/Link Flair Customization.css
@@ -1,5 +1,6 @@
 /* --- Addon: Linkflair Example --- */
 .linkflair-example .title > .linkflairlabel,
+.linkflair-example .search-result-header > .linkflairlabel,
 .linkflair-example > .linkflairlabel {
     background-color: #7767DA;
 }

--- a/Addons/Link Flair Customization/Link Flair Customization.css
+++ b/Addons/Link Flair Customization/Link Flair Customization.css
@@ -1,5 +1,6 @@
 /* --- Addon: Linkflair Example --- */
-.linkflair-example .linkflairlabel {
+.linkflair-example .title > .linkflairlabel,
+.linkflair-example > .linkflairlabel {
     background-color: #7767DA;
 }
 


### PR DESCRIPTION
If following this example then the flair class of the overall post is being applied to all flairs in the "Select Flair" menu, since the flairs in the selector are still children of the posts ".linkflair-example" class.

**Broken example using this code:**
![image](https://user-images.githubusercontent.com/11231402/84616825-0c6f3500-ae9b-11ea-839e-f7c39d201c4a.png)

**Fixed format by applying to title separately from other cases:**
![image](https://user-images.githubusercontent.com/11231402/84616839-14c77000-ae9b-11ea-976d-dd737c15edf0.png)
